### PR TITLE
Turbogeth service example

### DIFF
--- a/YagnaSharpApi.Examples/BlenderExample.cs
+++ b/YagnaSharpApi.Examples/BlenderExample.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using YagnaSharpApi.Engine;
+using YagnaSharpApi.Engine.Commands;
+using YagnaSharpApi.Utils;
+
+namespace YagnaSharpApi.Examples
+{
+
+
+    class BlenderExample
+    {
+
+        static async IAsyncEnumerable<WorkItem> Worker(WorkContext ctx, IAsyncEnumerable<GolemTask<int, string>> tasks)
+        {
+            var scenePath = /* scriptDir + */ "/cubes.blend";
+            ctx.SendFile(scenePath, "/golem/resource/scene.blend");
+            await foreach (var task in tasks)
+            {
+                var frame = task.Data;
+                ctx.SendJson("/golem/work/params.json",
+                    new
+                    {
+                        scene_file = "/golem/resource/scene.blend",
+                        resolution = (40, 30),
+                        use_compositing = false,
+                        crops = new[] { new { outfilebasename = "out", borders_x = new[] { 0.0, 1.0 }, borders_y = new[] { 0.0, 1.0 } } },
+                        samples = 100,
+                        frames = new[] { frame },
+                        output_format = "PNG",
+                        RESOURCES_DIR = "/golem/resources",
+                        WORK_DIR = "/golem/work",
+                        OUTPUT_DIR = "/golem/output"
+                    });
+
+                ctx.Run("/golem/entrypoints/run-blender.sh");
+                var outputFile = $"output_{frame}.png";
+                ctx.DownloadFile($"/golem/output/out{frame:04d}.png", outputFile);
+                yield return ctx.Commit();
+                // TODO check if results are valid
+                task.AcceptTask(outputFile);
+            }
+
+        }
+
+        public static async Task MainAsync(string subnetTag)
+        { 
+            var package = VmRequestBuilder.Repo(
+                "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
+                0.5m,
+                2.0m
+                );
+
+            // iterator over the frame indices that we want to render
+            var frames = Enumerable.Range(0,6);
+            // TODO make this dynamic, e.g. depending on the size of files to transfer
+            // worst-case time overhead for initialization, e.g. negotiation, file transfer etc.
+            var initOverhead = 3 * 60m; // 3 minutes
+
+            using (var executor = new Engine.Executor(
+                package, 
+                3, 
+                initOverhead + frames.Count() * 2,
+                120, 
+                subnetTag))
+            {
+                await foreach(var task in executor.SubmitAsync(Worker, frames.Select(frame => new GolemTask<int, string>(frame*10))))
+                {
+                    Console.WriteLine($"{TextColorConstants.TEXT_COLOR_CYAN}Task computed: {task}, result: {task.Result}{TextColorConstants.TEXT_COLOR_DEFAULT}");
+                }
+            }
+        }
+    }
+}

--- a/YagnaSharpApi.Examples/GethClient.cs
+++ b/YagnaSharpApi.Examples/GethClient.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace YagnaSharpApi.Examples
+{
+    /// <summary>
+    /// Class to abstract calls to a sample Geth RPC endpoint
+    /// </summary>    
+    class GethClient
+    {
+        public GethClient(string rpcEntpointUrl)
+        {
+
+        }
+    }
+}

--- a/YagnaSharpApi.Examples/Program.cs
+++ b/YagnaSharpApi.Examples/Program.cs
@@ -12,70 +12,10 @@ namespace YagnaSharpApi.Examples
 
     class Program
     {
-
-        static async IAsyncEnumerable<WorkItem> Worker(WorkContext ctx, IAsyncEnumerable<GolemTask<int, string>> tasks)
-        {
-            var scenePath = /* scriptDir + */ "/cubes.blend";
-            ctx.SendFile(scenePath, "/golem/resource/scene.blend");
-            await foreach (var task in tasks)
-            {
-                var frame = task.Data;
-                ctx.SendJson("/golem/work/params.json",
-                    new
-                    {
-                        scene_file = "/golem/resource/scene.blend",
-                        resolution = (40, 30),
-                        use_compositing = false,
-                        crops = new[] { new { outfilebasename = "out", borders_x = new[] { 0.0, 1.0 }, borders_y = new[] { 0.0, 1.0 } } },
-                        samples = 100,
-                        frames = new[] { frame },
-                        output_format = "PNG",
-                        RESOURCES_DIR = "/golem/resources",
-                        WORK_DIR = "/golem/work",
-                        OUTPUT_DIR = "/golem/output"
-                    });
-
-                ctx.Run("/golem/entrypoints/run-blender.sh");
-                var outputFile = $"output_{frame}.png";
-                ctx.DownloadFile($"/golem/output/out{frame:04d}.png", outputFile);
-                yield return ctx.Commit();
-                // TODO check if results are valid
-                task.AcceptTask(outputFile);
-            }
-
-        }
-
         static void Main(string[] args)
         {
-            Task.Run(async () => await MainAsync(args[0]));
+            Task.WaitAll(Task.Run(async () => await BlenderExample.MainAsync(args[0])));
         }
 
-        static async Task MainAsync(string subnetTag)
-        { 
-            var package = VmRequestBuilder.Repo(
-                "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
-                0.5m,
-                2.0m
-                );
-
-            // iterator over the frame indices that we want to render
-            var frames = Enumerable.Range(0,6);
-            // TODO make this dynamic, e.g. depending on the size of files to transfer
-            // worst-case time overhead for initialization, e.g. negotiation, file transfer etc.
-            var initOverhead = 3 * 60m; // 3 minutes
-
-            using (var executor = new Engine.Executor(
-                package, 
-                3, 
-                initOverhead + frames.Count() * 2,
-                120, 
-                subnetTag))
-            {
-                await foreach(var task in executor.SubmitAsync(Worker, frames.Select(frame => new GolemTask<int, string>(frame*10))))
-                {
-                    Console.WriteLine($"{TextColorConstants.TEXT_COLOR_CYAN}Task computed: {task}, result: {task.Result}{TextColorConstants.TEXT_COLOR_DEFAULT}");
-                }
-            }
-        }
     }
 }

--- a/YagnaSharpApi.Examples/TurbogethExample.cs
+++ b/YagnaSharpApi.Examples/TurbogethExample.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using YagnaSharpApi.Engine;
+using YagnaSharpApi.Engine.Commands;
+using YagnaSharpApi.Utils;
+
+namespace YagnaSharpApi.Examples
+{
+
+
+    class TurbogethExample
+    {
+        public static async Task MainAsync(string subnetTag)
+        { 
+            using (var executor = new Engine.Executor(
+                null, 
+                3, 
+                10.0m,
+                0, 
+                subnetTag))
+            {
+                await foreach(var service in executor.RunServiceAsync<TurbogethService>())
+                {
+                    // Service launched
+                }
+            }
+        }
+    }
+}

--- a/YagnaSharpApi.Examples/TurbogethPayload.cs
+++ b/YagnaSharpApi.Examples/TurbogethPayload.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using YagnaSharpApi.Utils;
+
+namespace YagnaSharpApi.Examples
+{
+    class TurbogethPayload : IPackage
+    {
+        public async Task DecorateDemandAsync(DemandBuilder builder)
+        {
+            builder.Ensure($"{Properties.RUNTIME_NAME}={"turbogeth-managed"}");
+            builder.Ensure($"{Properties.INF_MEM_GIB}>={16}");
+            builder.Ensure($"{Properties.INF_STORAGE_GIB}>={1024}");
+        }
+
+        public Task<string> ResolveUrlAsync()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/YagnaSharpApi.Examples/TurbogethService.cs
+++ b/YagnaSharpApi.Examples/TurbogethService.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using YagnaSharpApi.Engine;
+using YagnaSharpApi.Engine.Commands;
+using YagnaSharpApi.Utils;
+
+namespace YagnaSharpApi.Examples
+{
+    public class TurbogethService : ServiceBase
+    {
+        private bool disposedValue;
+
+        public string rpcEndpointUrl { get; private set; }
+
+        public TurbogethService() : base()
+        {
+        }
+
+        /// <summary>
+        /// Indicate payload specification.
+        /// </summary>
+        /// <returns></returns>
+        public override IPackage GetPayload()
+        {
+            return new TurbogethPayload();
+        }
+
+        /// <summary>
+        /// Define actions to be taken on startup of the Turbogeth service:
+        /// - Deploy and extract the RPC endpoint URL.
+        /// - Start
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <returns></returns>
+        public async override IAsyncEnumerable<WorkItem> OnStartupAsync(WorkContext ctx)
+        {
+            var deployStep = ctx.Deploy();
+            ctx.Start();
+
+            yield return ctx.Commit(); 
+
+            var deployResult = deployStep.Result;
+
+            this.rpcEndpointUrl = deployResult.Stdout; // just as simplistic example, in reality Deploy would return a JSON which would need ot be parsed
+        }
+
+        /// <summary>
+        /// Define actions to be executed while the service is up.
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <param name="cancellationToken">CancellationToken injected by the framework - 
+        /// to indicate the Run has been interrupted.</param>
+        /// <returns></returns>
+        public async override IAsyncEnumerable<WorkItem> OnRunAsync(WorkContext ctx, CancellationToken cancellationToken)
+        {
+            var gethClient = new GethClient(this.rpcEndpointUrl);
+
+            while(!cancellationToken.IsCancellationRequested)
+            {
+                // do periodic Turbogeth status check
+                // do periodic Activity accrued cost check
+
+            }
+            yield break;
+        }
+
+        /// <summary>
+        /// Specify actions to be taken on service shutdown.
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <param name="error"></param>
+        /// <returns></returns>
+        public async override IAsyncEnumerable<WorkItem> OnShutdownAsync(WorkContext ctx, Exception error = null)
+        {
+            // do nothing
+            yield break;
+        }
+    }
+}

--- a/YagnaSharpApi.Examples/TurbogethService.cs
+++ b/YagnaSharpApi.Examples/TurbogethService.cs
@@ -40,7 +40,7 @@ namespace YagnaSharpApi.Examples
 
             yield return ctx.Commit(); 
 
-            var deployResult = deployStep.Result;
+            var deployResult = await deployStep;
 
             this.rpcEndpointUrl = deployResult.Stdout; // just as simplistic example, in reality Deploy would return a JSON which would need ot be parsed
         }

--- a/YagnaSharpApi.Tests/ExecutorTests.cs
+++ b/YagnaSharpApi.Tests/ExecutorTests.cs
@@ -72,8 +72,13 @@ namespace YagnaSharpApi.Tests
                 await foreach (var task in tasks)
                 {
                     System.Diagnostics.Debug.WriteLine("Starting Task Body...");
-                    ctx.Prepare();  // force the init steps to be added to exescript (DEPLOY/START)
+                    var initStep = ctx.Prepare();  // force the init steps to be added to exescript (DEPLOY/START)
                     yield return ctx.Commit();
+
+                    // assert that the command results have been recorded
+                    Assert.IsNotNull(initStep.DeployResult);
+                    Assert.IsNotNull(initStep.StartResult);
+
                     // always accept
                     System.Diagnostics.Debug.WriteLine("Accepting Task results...");
                     task.AcceptTask("dummy");

--- a/YagnaSharpApi.Tests/IndexedWorkItemTests.cs
+++ b/YagnaSharpApi.Tests/IndexedWorkItemTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+using YagnaSharpApi.Engine.Commands;
+
+namespace YagnaSharpApi.Tests
+{
+    [TestClass]
+    public class IndexedWorkItemTests
+    {
+        [TestMethod]
+        public async Task IndexedWorkItem_AwaitableWorks()
+        {
+            var iwi = new DeployStep();
+            
+
+            Task.Run(async () =>
+            {
+                await Task.Delay(200);
+                iwi.StoreResult(new Golem.ActivityApi.Client.Model.ExeScriptCommandResult() { 
+                    Result = Golem.ActivityApi.Client.Model.ExeScriptCommandResult.ResultEnum.Ok,
+                    Message = "Result arrived"                
+                });
+            });
+            
+            var result = await iwi;
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual("Result arrived", result.Message);
+
+        }
+    }
+}

--- a/YagnaSharpApi/Engine/Commands/DeployStep.cs
+++ b/YagnaSharpApi/Engine/Commands/DeployStep.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace YagnaSharpApi.Engine.Commands
+{
+    public class DeployStep : IndexedWorkItem
+    {
+        public override void Register(ExeScriptBuilder commands)
+        {
+            this.CommandIndex = commands.Deploy();
+        }
+    }
+}

--- a/YagnaSharpApi/Engine/Commands/IndexedWorkItem.cs
+++ b/YagnaSharpApi/Engine/Commands/IndexedWorkItem.cs
@@ -1,0 +1,27 @@
+﻿using Golem.ActivityApi.Client.Model;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace YagnaSharpApi.Engine.Commands
+{
+    public abstract class IndexedWorkItem : WorkItem
+    {
+        public int CommandIndex { get; protected set; }
+        public ExeScriptCommandResult Result { get; set; }
+
+        public override void StoreResult(ExeScriptCommandResult result)
+        {
+            if(this.CommandIndex == result.Index)
+            {
+                this.Result = result;
+            }
+        }
+
+        public override IEnumerable<ExeScriptCommandResult> GetResults()
+        {
+            yield return this.Result;
+        }
+    }
+}

--- a/YagnaSharpApi/Engine/Commands/IndexedWorkItem.cs
+++ b/YagnaSharpApi/Engine/Commands/IndexedWorkItem.cs
@@ -1,6 +1,7 @@
 ﻿using Golem.ActivityApi.Client.Model;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -9,13 +10,31 @@ namespace YagnaSharpApi.Engine.Commands
     public abstract class IndexedWorkItem : WorkItem
     {
         public int CommandIndex { get; protected set; }
-        public ExeScriptCommandResult Result { get; set; }
+
+        private TaskCompletionSource<ExeScriptCommandResult> resultTaskCompletionSource;
+
+        private ExeScriptCommandResult Result;
+
+
+        public TaskAwaiter<ExeScriptCommandResult> GetAwaiter()
+        {
+            if (this.resultTaskCompletionSource == null)
+            {
+                this.resultTaskCompletionSource = new TaskCompletionSource<ExeScriptCommandResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+
+            return this.resultTaskCompletionSource.Task.GetAwaiter();
+        }
 
         public override void StoreResult(ExeScriptCommandResult result)
         {
             if(this.CommandIndex == result.Index)
             {
                 this.Result = result;
+                if (this.resultTaskCompletionSource != null)
+                {
+                    this.resultTaskCompletionSource.SetResult(result);
+                }
             }
         }
 

--- a/YagnaSharpApi/Engine/Commands/InitStep.cs
+++ b/YagnaSharpApi/Engine/Commands/InitStep.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Golem.ActivityApi.Client.Model;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -6,10 +7,35 @@ namespace YagnaSharpApi.Engine.Commands
 {
     public class InitStep : WorkItem
     {
+        private int deployIndex;
+        private int startIndex;
+
+        public ExeScriptCommandResult DeployResult { get; set; }
+        public ExeScriptCommandResult StartResult { get; set; }
+
         public override void Register(ExeScriptBuilder commands)
         {
-            commands.Deploy();
-            commands.Start();
+            this.deployIndex = commands.Deploy();
+            this.startIndex = commands.Start();
+        }
+
+        public override void StoreResult(ExeScriptCommandResult result)
+        {
+            if(result.Index == deployIndex)
+            {
+                this.DeployResult = result;
+            }
+
+            if (result.Index == startIndex)
+            {
+                this.StartResult = result;
+            }
+        }
+
+        public override IEnumerable<ExeScriptCommandResult> GetResults()
+        {
+            yield return this.DeployResult;
+            yield return this.StartResult;
         }
     }
 }

--- a/YagnaSharpApi/Engine/Commands/RecvFile.cs
+++ b/YagnaSharpApi/Engine/Commands/RecvFile.cs
@@ -6,9 +6,8 @@ using YagnaSharpApi.Storage;
 
 namespace YagnaSharpApi.Engine.Commands
 {
-    public class RecvFile : WorkItem
+    public class RecvFile : IndexedWorkItem
     {
-        public int Index { get; set; }
         protected IOutputStorageProvider storage;
         protected string srcPath;
         protected string destPath;
@@ -28,7 +27,7 @@ namespace YagnaSharpApi.Engine.Commands
 
         public override void Register(ExeScriptBuilder commands)
         {
-            this.Index = commands.Transfer($"container:{this.srcPath}", this.destSlot.UploadUrl());
+            this.CommandIndex = commands.Transfer($"container:{this.srcPath}", this.destSlot.UploadUrl());
         }
 
         public async override Task Post()

--- a/YagnaSharpApi/Engine/Commands/Run.cs
+++ b/YagnaSharpApi/Engine/Commands/Run.cs
@@ -4,9 +4,8 @@ using System.Text;
 
 namespace YagnaSharpApi.Engine.Commands
 {
-    public class Run : WorkItem
+    public class Run : IndexedWorkItem
     {
-        public int Index { get; private set; }
         private string cmd;
         private string[] args;
 
@@ -18,7 +17,7 @@ namespace YagnaSharpApi.Engine.Commands
 
         public override void Register(ExeScriptBuilder commands)
         {
-            this.Index = commands.Run(cmd, args);
+            this.CommandIndex = commands.Run(cmd, args);
         }
     }
 }

--- a/YagnaSharpApi/Engine/Commands/SendWork.cs
+++ b/YagnaSharpApi/Engine/Commands/SendWork.cs
@@ -6,9 +6,8 @@ using YagnaSharpApi.Storage;
 
 namespace YagnaSharpApi.Engine.Commands
 {
-    public abstract class SendWork : WorkItem
+    public abstract class SendWork : IndexedWorkItem
     {
-        public int Index { get; set; }
         protected ISource src;
         protected string destPath;
         protected IInputStorageProvider storage;
@@ -33,7 +32,7 @@ namespace YagnaSharpApi.Engine.Commands
 
         public override void Register(ExeScriptBuilder commands)
         {
-            this.Index = commands.Transfer(this.src.DownloadUrl(), $"container:{this.destPath}");
+            this.CommandIndex = commands.Transfer(this.src.DownloadUrl(), $"container:{this.destPath}");
         }
     }
 }

--- a/YagnaSharpApi/Engine/Commands/StartStep.cs
+++ b/YagnaSharpApi/Engine/Commands/StartStep.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace YagnaSharpApi.Engine.Commands
+{
+    public class StartStep : IndexedWorkItem
+    {
+        public override void Register(ExeScriptBuilder commands)
+        {
+            this.CommandIndex = commands.Deploy();
+        }
+    }
+}

--- a/YagnaSharpApi/Engine/Commands/Steps.cs
+++ b/YagnaSharpApi/Engine/Commands/Steps.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Golem.ActivityApi.Client.Model;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -35,6 +36,25 @@ namespace YagnaSharpApi.Engine.Commands
             foreach (var step in steps)
             {
                 await step.Post();
+            }
+        }
+
+        public override void StoreResult(ExeScriptCommandResult result)
+        {
+            foreach (var step in steps)
+            {
+                step.StoreResult(result);
+            }
+        }
+
+        public override IEnumerable<ExeScriptCommandResult> GetResults()
+        {
+            foreach(var step in this.steps)
+            {
+                foreach(var result in step.GetResults())
+                {
+                    yield return result;
+                }
             }
         }
     }

--- a/YagnaSharpApi/Engine/Commands/WorkItem.cs
+++ b/YagnaSharpApi/Engine/Commands/WorkItem.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Golem.ActivityApi.Client.Model;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -18,5 +19,18 @@ namespace YagnaSharpApi.Engine.Commands
         {
 
         }
+
+        /// <summary>
+        /// Once a single ExeScript command result is received - record it against a respective workitem.
+        /// Note that in reality only the IndexedWorkItem subclasses can reliably record the results...
+        /// </summary>
+        /// <param name="result"></param>
+        public abstract void StoreResult(ExeScriptCommandResult result);
+
+        /// <summary>
+        /// Extract the results received by this workitem
+        /// </summary>
+        /// <returns></returns>
+        public abstract IEnumerable<ExeScriptCommandResult> GetResults();
     }
 }

--- a/YagnaSharpApi/Engine/Executor.cs
+++ b/YagnaSharpApi/Engine/Executor.cs
@@ -283,6 +283,27 @@ namespace YagnaSharpApi.Engine
             this.OnExecutorEvent?.Invoke(this, new SubmitFinished());
         }
 
+        /// <summary>
+        /// Runs a service of type specified by generic parameter, 
+        /// in a number of instances indicated by numInstances param.
+        /// 
+        /// 
+        /// </summary>
+        /// <typeparam name="Service"></typeparam>
+        /// <param name="numInstances"></param>
+        /// <returns>Collection of Instances of the Service class which had been launched.</returns>
+        public async IAsyncEnumerable<Service> RunServiceAsync<Service>(int numInstances = 1) 
+            where Service : ServiceBase, new()
+        {
+            // TODO : handle the long running service execution
+            for (int i = 0; i < numInstances; i++)
+            {
+                var service = new Service();
+
+                yield return service;
+            }
+        }
+
         protected async Task<IEnumerable<AllocationEntity>> CreateAllocationsAsync()
         {
             var result = new List<AllocationEntity>();
@@ -447,6 +468,8 @@ namespace YagnaSharpApi.Engine
 
                     await foreach (var result in commandResults)
                     {
+                        batch.StoreResult(result);
+
                         // TODO raise command executed event
                         if (result.Result == Golem.ActivityApi.Client.Model.ExeScriptCommandResult.ResultEnum.Error)
                             throw new CommandExecutionException(commands[result.Index], result); 

--- a/YagnaSharpApi/Engine/ServiceBase.cs
+++ b/YagnaSharpApi/Engine/ServiceBase.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using YagnaSharpApi.Engine.Commands;
+using YagnaSharpApi.Utils;
+
+namespace YagnaSharpApi.Engine
+{
+    public abstract class ServiceBase : IDisposable
+    {
+        private bool disposedValue;
+
+        public enum ServiceStateEnum
+        {
+            New,
+            Starting,
+            Running,
+            Unresponsive,
+            ShuttingDown,
+            Finished,
+            Error
+        }
+
+        public CancellationToken CancellationToken { get; set; }
+        public CancellationTokenSource CancellationTokenSource { get; set; }
+
+        public ServiceBase()
+        {
+            this.CancellationTokenSource = new CancellationTokenSource();
+            this.CancellationToken = this.CancellationTokenSource.Token;
+        }
+
+        public ServiceStateEnum State { get; set; }
+
+        /// <summary>
+        /// Returns the definition of service payload.
+        /// </summary>
+        /// <returns></returns>
+        public abstract IPackage GetPayload();
+
+        /// <summary>
+        /// Specifies actions to be executed on Provider when the service is being launched.
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <returns></returns>
+        public abstract IAsyncEnumerable<WorkItem> OnStartupAsync(WorkContext ctx);
+        
+        /// <summary>
+        /// Specifies actions which are to be executed on Provider while the service is running.
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <returns></returns>
+        public abstract IAsyncEnumerable<WorkItem> OnRunAsync(WorkContext ctx, CancellationToken cancellationToken);
+        
+        /// <summary>
+        /// Specifies actions to be executed on Provider while the service is being shut down.
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <returns></returns>
+        public abstract IAsyncEnumerable<WorkItem> OnShutdownAsync(WorkContext ctx, Exception error = null);
+
+        /// <summary>
+        /// Request service shutdown
+        /// </summary>
+        public void Shutdown()
+        {
+
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    this.CancellationTokenSource.Dispose();
+                }
+                disposedValue = true;
+            }
+        }
+
+        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
+        // ~ServiceBase()
+        // {
+        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        //     Dispose(disposing: false);
+        // }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/YagnaSharpApi/Engine/WorkContext.cs
+++ b/YagnaSharpApi/Engine/WorkContext.cs
@@ -20,37 +20,79 @@ namespace YagnaSharpApi.Engine
             this.storage = storage;
         }
 
-        public void Prepare()
+        /// <summary>
+        /// Adds an InitStep to the batch, if the batch hasn't yet included a starting command.
+        /// Otherwise it returns null.
+        /// </summary>
+        /// <returns></returns>
+        public InitStep Prepare()
         {
             if(! this.started)
             {
-                this.pendingSteps.Add(new InitStep());
+                var initStep = new InitStep();
+                this.pendingSteps.Add(initStep);
                 this.started = true;
+                return initStep;
             }
+            return null;
         }
 
-        public void SendJson(string destPath, object data)
+        /// <summary>
+        /// Adds DeployStep to the batch (if not started yet).
+        /// </summary>
+        public IndexedWorkItem Deploy()
         {
-            this.Prepare();
-            this.pendingSteps.Add(new SendJson(this.storage, data, destPath));
+            if (!this.started)
+            {
+                var deployStep = new DeployStep();
+                this.pendingSteps.Add(deployStep);
+                return deployStep;
+            }
+            return null;
         }
 
-        public void SendFile(string srcPath, string destPath)
+        public IndexedWorkItem Start()
         {
-            this.Prepare();
-            this.pendingSteps.Add(new SendFile(this.storage, srcPath, destPath));
+            if (!this.started)
+            {
+                var startStep = new StartStep();
+                this.pendingSteps.Add(startStep);
+                this.started = true;
+                return startStep;
+            }
+            return null;
         }
 
-        public void Run(string cmd, params string[] args)
+        public IndexedWorkItem SendJson(string destPath, object data)
         {
             this.Prepare();
-            this.pendingSteps.Add(new Run(cmd, args));
+            var sendJson = new SendJson(this.storage, data, destPath);
+            this.pendingSteps.Add(sendJson);
+            return sendJson;
         }
 
-        public void DownloadFile(string srcPath, string destPath)
+        public IndexedWorkItem SendFile(string srcPath, string destPath)
         {
             this.Prepare();
-            this.pendingSteps.Add(new RecvFile(this.storage, srcPath, destPath));
+            var sendFile = new SendFile(this.storage, srcPath, destPath);
+            this.pendingSteps.Add(sendFile);
+            return sendFile;
+        }
+
+        public IndexedWorkItem Run(string cmd, params string[] args)
+        {
+            this.Prepare();
+            var run = new Run(cmd, args);
+            this.pendingSteps.Add(run);
+            return run;
+        }
+
+        public IndexedWorkItem DownloadFile(string srcPath, string destPath)
+        {
+            this.Prepare();
+            var recvFile = new RecvFile(this.storage, srcPath, destPath);
+            this.pendingSteps.Add(recvFile);
+            return recvFile;
         }
 
         public WorkItem Commit()

--- a/YagnaSharpApi/Utils/VmRequestBuilder.cs
+++ b/YagnaSharpApi/Utils/VmRequestBuilder.cs
@@ -1,16 +1,41 @@
-﻿using System;
+﻿using DnsClient;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace YagnaSharpApi.Utils
 {
     public class VmRequestBuilder
     {
-        protected const string DEFAULT_REPO_URL = "http://yacn2.dev.golem.network:8000";
+        protected const string DEFAULT_REPO_URL = "_girepo._tcp.dev.golem.network";
+        protected const string FALLBACK_REPO_URL = "http://yacn2.dev.golem.network:8000";
 
         public static IPackage Repo(string imageHash, decimal minMemGiB = 0.5m, decimal minStorageGiB = 2.0m)
         {
-            return new VmPackage(DEFAULT_REPO_URL, imageHash, new VmConstraints(minMemGiB, minStorageGiB));
+
+            return new VmPackage(ResolveRepoUrl(DEFAULT_REPO_URL), imageHash, new VmConstraints(minMemGiB, minStorageGiB));
+        }
+
+        public static string ResolveRepoUrl(string address)
+        {
+            try
+            {
+                var client = new LookupClient();
+
+                var result = client.Query(address, QueryType.SRV);
+
+                foreach (var srvRecord in client.Query(address, QueryType.SRV).Answers.SrvRecords())
+                {
+                    return $"http://{srvRecord.Target}:{srvRecord.Port}";
+                }
+            }
+            catch(Exception exc)
+            {
+                // TODO log warning
+            }
+
+            return FALLBACK_REPO_URL;
         }
     }
 }

--- a/YagnaSharpApi/Utils/VmRequestBuilder.cs
+++ b/YagnaSharpApi/Utils/VmRequestBuilder.cs
@@ -6,7 +6,7 @@ namespace YagnaSharpApi.Utils
 {
     public class VmRequestBuilder
     {
-        protected const string DEFAULT_REPO_URL = "http://3.249.139.167:8000";
+        protected const string DEFAULT_REPO_URL = "http://yacn2.dev.golem.network:8000";
 
         public static IPackage Repo(string imageHash, decimal minMemGiB = 0.5m, decimal minStorageGiB = 2.0m)
         {

--- a/YagnaSharpApi/YagnaSharpApi.csproj
+++ b/YagnaSharpApi/YagnaSharpApi.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
+    <PackageReference Include="DnsClient" Version="1.4.0" />
     <PackageReference Include="StreamJsonRpc" Version="2.6.121" />
     <PackageReference Include="System.Linq.Async" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Sketches for long-running service support in Golem C# API.

Highlights:
- Service class instead of the "worker generator"
- Added ability to retrieve ExeScript command results from WorkContext batches.
- Executor.RunServiceAsync() method interface defined.
- Turbogeth code sample
  - Turbogeth Payload sample
  - TurbogethService definition

